### PR TITLE
Use gometalinter to get its own tools

### DIFF
--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -40,7 +40,10 @@ RUN echo "GOTOOLSTOBUILD=$GOTOOLSTOBUILD"
 
 RUN for item in $GOTOOLSTOBUILD; do \
 	echo "Adding tool $item" && \
-	go get $item && \
-	go build -o /usr/local/bin/$(basename $item) $item; \
-	done
+	go get -u $item; \
+done
 
+RUN gometalinter --install
+
+# /go/bin will be mounted on top, so get everything into /usr/local/bin
+RUN cp -r /go/bin/* /usr/local/bin


### PR DESCRIPTION
## The Problem:

I didn't have all the linters properly installed in https://github.com/drud/golang-build-container/pull/3, so a bit of a do-over

## The Fix:

* Build everything into normal go/bin, then copy it into /usr/local/bin later
* Let gometalinter install its own linters

## The Test:

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

