### PR TITLE
Upgrade golang to 1.8.3

### DIFF
--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -1,7 +1,5 @@
 FROM UPSTREAM_REPO
 
-MAINTAINER Randy Fay <rfay@drud.com>
-
 RUN apk update && apk add git bash build-base
 
 # discussion of various tools at

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ PKG := github.com/drud/golang-build-container
 DOCKER_REPO ?= drud/golang-build-container
 
 # Upstream repo used in the Dockerfile
-UPSTREAM_REPO ?= golang:1.8.1-alpine
+UPSTREAM_REPO ?= golang:1.8.3-alpine
 
 # Top-level directories to build
 # SRC_DIRS := files drudapi secrets utils


### PR DESCRIPTION
## The Problem:

Golang has moved along to 1.8.3, time to follow.

## The Fix:

## The Test:

## Automation Overview:

## Related Issue Link(s):

https://github.com/drud/build-tools/pull/29 adds this into build-tools

## Release/Deployment notes:

This needs to be tagged as a release on github, then pushed to dockerhub. 
