### PR TITLE
Upgrade to golang 1.9.1

### DIFF
--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -1,4 +1,4 @@
-FROM UPSTREAM_REPO
+FROM golang:1.9.1-alpine
 
 RUN apk update && apk add git bash build-base
 

--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,6 @@ PKG := github.com/drud/golang-build-container
 # Docker repo for a push
 DOCKER_REPO ?= drud/golang-build-container
 
-# Upstream repo used in the Dockerfile
-UPSTREAM_REPO ?= golang:1.9.0-alpine
-
 # Top-level directories to build
 # SRC_DIRS := files drudapi secrets utils
 


### PR DESCRIPTION
## The Problem:

Golang 1.9.1 has come out. This upgrades the upstream container. 

## The Fix:

## The Test:

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

