### PR TITLE
Bump golang-build-container to 1.9.3

### DIFF
--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -1,4 +1,4 @@
-FROM golang:1.9.1-alpine
+FROM golang:1.9.3-alpine
 
 RUN apk update && apk add git bash build-base
 


### PR DESCRIPTION
## The Problem:

Time to upgrade golang.

This also pulls in all the various updated linting tools with a new build.

It's temporarily available at drud/golang-build-container:20180125_golang_1_9_3

## The Fix:

## Related Issue Link(s):

## Release/Deployment notes:

After this goes in, 
- [ ] make a release, 
- [ ] push the official docker image
- [ ] Move up the chain doing the same thing for build-tools (and then ddev for example)
