### PR TITLE
updates go get path for dep to include cmd

### DIFF
--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -17,7 +17,7 @@ ENV GOTOOLSTOBUILD \
         github.com/gordonklaus/ineffassign \
         github.com/jgautheron/goconst \
         github.com/kardianos/govendor \
-        github.com/golang/dep \
+        github.com/golang/dep/cmd/dep \
         github.com/Masterminds/glide \
         github.com/kisielk/errcheck \
         github.com/mdempsky/unconvert \


### PR DESCRIPTION
## The Problem:
I added dep and glide in #11, but it looks like I didn't quite get dep's path right to install the binary, as there is no 'dep' executable currently in the go container. womp womp.

## The Fix:

Specify the dep cmd path.

## The Test:

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

