### PR TITLE
Update golang to 1.10.0

### DIFF
--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -1,4 +1,4 @@
-FROM golang:1.9.3-alpine
+FROM golang:1.10.0-alpine
 
 RUN apk update && apk add git bash build-base
 

--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -47,3 +47,5 @@ RUN gometalinter --install
 
 # /go/bin will be mounted on top, so get everything into /usr/local/bin
 RUN cp -r /go/bin/* /usr/local/bin
+
+ENV GOCACHE /go/.cache


### PR DESCRIPTION
## The Problem:

golang 1.10! 

## The Fix:

Bump it. 

## The Manual Test:

A temporary image is at drud/golang-build-container:20180218_golang_1_10 for use. 

With anything that uses build-tools you can

`make BUILD_IMAGE=drud/golang-build-container:20180218_golang_1_10` 

and see how things come out. It's fun and profitable. Lots better caching.

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

