### PR TITLE
Bump golang-build-container to go 1.10.2

### DIFF
--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -1,4 +1,4 @@
-FROM golang:1.10.0-alpine
+FROM golang:1.10.2-alpine
 
 RUN apk update && apk add git bash build-base
 


### PR DESCRIPTION
## The Problem:

Go moves on

## The Fix:

Bump to 1.10.2
Pushed as drud/golang-build-container:20180605_go_1.10.2

## The Test:

Nothing really, should be all good.

## Release/Deployment notes:

After pull, make a release and push an official version.
Add it into build-tools.
Upgrade downstream.
