### PR TITLE
Add golangci-lint

### DIFF
--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -1,6 +1,9 @@
 FROM golang:1.10.3-alpine
+ENV GOLANGCI_LINT_VERSION v1.9.1
 
-RUN apk update && apk add git bash build-base
+RUN apk update && apk add git bash build-base curl
+
+RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b $GOPATH/bin $GOLANGCI_LINT_VERSION
 
 # discussion of various tools at
 # http://blog.ralch.com/tutorial/golang-tools-inspection/


### PR DESCRIPTION
## The Problem:

@beeradb wants golangci-lint, it's faster than gometalinter.

## The Fix:

Add it.

## The Test:

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

