### PR TITLE
Bump golang-build-container to v1.11

### DIFF
--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -1,5 +1,5 @@
-FROM golang:1.10.3-alpine
-ENV GOLANGCI_LINT_VERSION v1.9.1
+FROM golang:1.11-alpine
+ENV GOLANGCI_LINT_VERSION v1.10.2
 
 RUN apk update && apk add git bash build-base curl
 


### PR DESCRIPTION
## The Problem:

Time to bump golang to 1.11

## The Fix:

## The Test:

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

