### PR TITLE
Update golang to v1.11.2 (and golangci-lint)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM golang:1.11-alpine
-ENV GOLANGCI_LINT_VERSION v1.10.2
+FROM golang:1.11.2-alpine
+ENV GOLANGCI_LINT_VERSION v1.12.3
 
 RUN apk update && apk add git bash build-base curl
 

--- a/build-tools/build_update.sh
+++ b/build-tools/build_update.sh
@@ -40,7 +40,7 @@ tar -xf $local_file
 rm -rf build-tools/*
 cp -r $internal_name/ build-tools/
 rm -rf $internal_name/
-rm -rf build-tools/{tests,circle.yml,.circleci,.github,.appveyor.yml}
+rm -rf build-tools/{tests,circle.yml,.circleci,.github,.appveyor.yml,.buildkite}
 touch build-tools/build-tools-VERSION-$tag.txt
 git add build-tools
 echo "Updated build-tools to $tag

--- a/build-tools/makefile_components/base_build_go.mak
+++ b/build-tools/makefile_components/base_build_go.mak
@@ -5,7 +5,7 @@
 ##### comment about what you did and why.
 
 
-.PHONY: all build test push clean container-clean bin-clean version static govendor gofmt govet golint
+.PHONY: all build test push clean container-clean bin-clean version static govendor gofmt govet golint golangci-lint container
 GOTMP=.gotmp
 
 SHELL = /bin/bash
@@ -14,7 +14,7 @@ GOFILES = $(shell find $(SRC_DIRS) -name "*.go")
 
 BUILD_OS = $(shell go env GOHOSTOS)
 
-BUILD_IMAGE ?= drud/golang-build-container:v0.5.2
+BUILD_IMAGE ?= drud/golang-build-container:v1.11
 
 BUILD_BASE_DIR ?= $$PWD
 
@@ -23,6 +23,7 @@ SRC_AND_UNDER = $(patsubst %,./%/...,$(SRC_DIRS))
 
 GOMETALINTER_ARGS ?= --vendored-linters --disable-all --enable=gofmt --enable=vet --enable=vetshadow --enable=golint --enable=errcheck --enable=staticcheck --enable=ineffassign --enable=varcheck --enable=deadcode --deadline=2m
 
+GOLANGCI_LINT_ARGS ?= --out-format=line-number --disable-all --enable=gofmt --enable=govet --enable=golint --enable=errcheck --enable=staticcheck --enable=ineffassign --enable=varcheck --enable=deadcode
 
 COMMIT := $(shell git describe --tags --always --dirty)
 BUILDINFO = $(shell echo Built $$(date) $$(whoami)@$$(hostname) $(BUILD_IMAGE) )
@@ -35,26 +36,28 @@ LDFLAGS := -extldflags -static $(VERSION_LDFLAGS)
 DOCKERMOUNTFLAG := :delegated
 
 PWD=$(shell pwd)
+S =
 ifeq ($(BUILD_OS),windows)
-    TMPPWD=$(shell cmd /C echo %cd%)
-    PWD=$(shell echo "$(TMPPWD)" | awk '{gsub("\\\\", "/"); print}' )
+    # On Windows docker toolbox, volume mounts oddly need a // at the beginning for things to work out, so
+    # add that extra slash only on Windows.
+    S=/
 endif
 
-build: linux darwin
+build: $(BUILD_OS)
 
 linux darwin windows: $(GOFILES)
 	@echo "building $@ from $(SRC_AND_UNDER)"
 	@$(shell rm -f VERSION.txt)
 	@$(shell mkdir -p bin/$@ $(GOTMP)/{std/$@,bin,src/$(PKG)})
 	@docker run -t --rm -u $(shell id -u):$(shell id -g)                    \
-	    -v $(PWD)/$(GOTMP):/go$(DOCKERMOUNTFLAG)                                   \
-	    -v $(PWD):/go/src/$(PKG)$(DOCKERMOUNTFLAG)                                 \
-	    -v $(PWD)/bin/$@:/go/bin$(DOCKERMOUNTFLAG)                         \
-	    -v $(PWD)/bin/$@:/go/bin/$@$(DOCKERMOUNTFLAG)                 \
-	    -v $(PWD)/$(GOTMP)/std/$@:/usr/local/go/pkg/$@_amd64_static$(DOCKERMOUNTFLAG)  \
+	    -v "$(S)$$PWD/$(GOTMP):/go$(DOCKERMOUNTFLAG)"                                \
+	    -v "$(S)$$PWD:/go/src/$(PKG)$(DOCKERMOUNTFLAG)"                              \
+	    -v "$(S)$$PWD/bin/$@:/go/bin$(DOCKERMOUNTFLAG)"                        \
+	    -v "$(S)$$PWD/bin/$@:/go/bin/$@$(DOCKERMOUNTFLAG)"             \
+	    -v "$(S)$$PWD/$(GOTMP)/std/$@:/usr/local/go/pkg/$@_amd64_static$(DOCKERMOUNTFLAG)"  \
 	    -e CGO_ENABLED=0                  \
 	    -e GOOS=$@						  \
-	    -w /go/src/$(PKG)                 \
+	    -w $(S)/go/src/$(PKG)                 \
 	    $(BUILD_IMAGE)                    \
         go install -installsuffix static -ldflags ' $(LDFLAGS) ' $(SRC_AND_UNDER)
 	@$(shell touch $@)
@@ -63,72 +66,72 @@ linux darwin windows: $(GOFILES)
 govendor:
 	@echo -n "Using govendor to check for missing dependencies and unused dependencies: "
 	@docker run -t --rm -u $(shell id -u):$(shell id -g)                    \
-		-v $(PWD)/$(GOTMP):/go$(DOCKERMOUNTFLAG)                                   \
-		-v $(PWD):/go/src/$(PKG)$(DOCKERMOUNTFLAG)                                  \
-		-w /go/src/$(PKG)                                         \
+		-v $(S)$$PWD/$(GOTMP):/go$(DOCKERMOUNTFLAG)                                   \
+		-v $(S)$$PWD:/go/src/$(PKG)$(DOCKERMOUNTFLAG)                                  \
+		-w $(S)/go/src/$(PKG)                                         \
 		$(BUILD_IMAGE)                                                     \
 		bash -c 'OUT=$$(govendor list +missing +unused); if [ -n "$$OUT" ]; then echo "$$OUT"; exit 1; fi'
 
 gofmt:
 	@echo "Checking gofmt: "
 	@docker run -t --rm -u $(shell id -u):$(shell id -g)                    \
-		-v $(PWD)/$(GOTMP):/go$(DOCKERMOUNTFLAG)                                                 \
-		-v $(PWD):/go/src/$(PKG)$(DOCKERMOUNTFLAG)                                          \
-		-w /go/src/$(PKG)                                                  \
+		-v $(S)$$PWD/$(GOTMP):/go$(DOCKERMOUNTFLAG)                                                 \
+		-v $(S)$$PWD:/go/src/$(PKG)$(DOCKERMOUNTFLAG)                                          \
+		-w $(S)/go/src/$(PKG)                                                  \
 		$(BUILD_IMAGE)                                                     \
 		bash -c 'export OUT=$$(gofmt -l $(SRC_DIRS))  && if [ -n "$$OUT" ]; then echo "These files need gofmt -w: $$OUT"; exit 1; fi'
 
 govet:
 	@echo "Checking go vet: "
 	@docker run -t --rm -u $(shell id -u):$(shell id -g)                         \
-		-v $(PWD)/$(GOTMP):/go$(DOCKERMOUNTFLAG)                                                 \
-		-v $(PWD):/go/src/$(PKG)$(DOCKERMOUNTFLAG)                                          \
-		-w /go/src/$(PKG)                                                  \
+		-v $(S)$$PWD/$(GOTMP):/go$(DOCKERMOUNTFLAG)                                                 \
+		-v $(S)$$PWD:/go/src/$(PKG)$(DOCKERMOUNTFLAG)                                          \
+		-w $S/go/src/$(PKG)                                                  \
 		$(BUILD_IMAGE)                                                     \
 		bash -c 'go vet $(SRC_AND_UNDER)'
 
 golint:
 	@echo "Checking golint: "
 	@docker run -t --rm -u $(shell id -u):$(shell id -g)                   \
-		-v $(PWD)/$(GOTMP):/go$(DOCKERMOUNTFLAG)                                                 \
-		-v $(PWD):/go/src/$(PKG)$(DOCKERMOUNTFLAG)                                          \
-		-w /go/src/$(PKG)                                                  \
+		-v $(S)$$PWD/$(GOTMP):/go$(DOCKERMOUNTFLAG)                                                 \
+		-v $(S)$$PWD:/go/src/$(PKG)$(DOCKERMOUNTFLAG)                                          \
+		-w $(S)/go/src/$(PKG)                                                  \
 		$(BUILD_IMAGE)                                                     \
 		bash -c 'export OUT=$$(golint $(SRC_AND_UNDER)) && if [ -n "$$OUT" ]; then echo "Golint problems discovered: $$OUT"; exit 1; fi'
 
 errcheck:
 	@echo "Checking errcheck: "
 	@docker run -t --rm -u $(shell id -u):$(shell id -g)                   \
-		-v $(PWD)/$(GOTMP):/go$(DOCKERMOUNTFLAG)                                                 \
-		-v $(PWD):/go/src/$(PKG)$(DOCKERMOUNTFLAG)                                          \
-		-w /go/src/$(PKG)                                                  \
+		-v $(S)$$PWD/$(GOTMP):/go$(DOCKERMOUNTFLAG)                                                 \
+		-v $(S)$$PWD:/go/src/$(PKG)$(DOCKERMOUNTFLAG)                                          \
+		-w $(S)/go/src/$(PKG)                                                  \
 		$(BUILD_IMAGE)                                                     \
 		errcheck $(SRC_AND_UNDER)
 
 staticcheck:
 	@echo "Checking staticcheck: "
 	@docker run -t --rm -u $(shell id -u):$(shell id -g)                         \
-		-v $(PWD)/$(GOTMP):/go$(DOCKERMOUNTFLAG)                                                 \
-		-v $(PWD):/go/src/$(PKG)$(DOCKERMOUNTFLAG)                                          \
-		-w /go/src/$(PKG)                                                  \
+		-v $(S)$$PWD/$(GOTMP):/go$(DOCKERMOUNTFLAG)                                                 \
+		-v $(S)$$PWD:/go/src/$(PKG)$(DOCKERMOUNTFLAG)                                          \
+		-w $(S)/go/src/$(PKG)                                                  \
 		$(BUILD_IMAGE)                                                     \
 		staticcheck $(SRC_AND_UNDER)
 
 unused:
 	@echo "Checking unused variables and functions: "
 	@docker run -t --rm -u $(shell id -u):$(shell id -g)                         \
-		-v $(PWD)/$(GOTMP):/go$(DOCKERMOUNTFLAG)                                                 \
-		-v $(PWD):/go/src/$(PKG)$(DOCKERMOUNTFLAG)                                          \
-		-w /go/src/$(PKG)                                                  \
+		-v $(S)$$PWD/$(GOTMP):/go$(DOCKERMOUNTFLAG)                                                 \
+		-v $(S)$$PWD:/go/src/$(PKG)$(DOCKERMOUNTFLAG)                                          \
+		-w $(S)/go/src/$(PKG)                                                  \
 		$(BUILD_IMAGE)                                                     \
 		unused $(SRC_AND_UNDER)
 
 codecoroner:
 	@echo "Checking codecoroner for unused functions: "
 	@docker run -t --rm -u $(shell id -u):$(shell id -g)                         \
-		-v $(PWD)/$(GOTMP):/go$(DOCKERMOUNTFLAG)                                                 \
-		-v $(PWD):/go/src/$(PKG)$(DOCKERMOUNTFLAG)                                          \
-		-w /go/src/$(PKG)                                                  \
+		-v $(S)$$PWD/$(GOTMP):/go$(DOCKERMOUNTFLAG)                                                 \
+		-v $(S)$$PWD:/go/src/$(PKG)$(DOCKERMOUNTFLAG)                                          \
+		-w $(S)/go/src/$(PKG)                                                  \
 		$(BUILD_IMAGE) \
 		bash -c 'OUT=$$(codecoroner -tests -ignore vendor funcs $(SRC_AND_UNDER)); if [ -n "$$OUT" ]; then echo "$$OUT"; exit 1; fi'                                             \
 
@@ -136,37 +139,48 @@ codecoroner:
 varcheck:
 	@echo "Checking unused globals and struct members: "
 	@docker run -t --rm -u $(shell id -u):$(shell id -g)                         \
-		-v $(PWD)/$(GOTMP):/go$(DOCKERMOUNTFLAG)                                                 \
-		-v $(PWD):/go/src/$(PKG)$(DOCKERMOUNTFLAG)                                          \
-		-w /go/src/$(PKG)                                                  \
+		-v $(S)$$PWD/$(GOTMP):/go$(DOCKERMOUNTFLAG)                                                 \
+		-v $(S)$$PWD:/go/src/$(PKG)$(DOCKERMOUNTFLAG)                                          \
+		-w $(S)/go/src/$(PKG)                                                  \
 		$(BUILD_IMAGE)                                                     \
 		varcheck $(SRC_AND_UNDER) && structcheck $(SRC_AND_UNDER)
 
 misspell:
 	@echo "Checking for misspellings: "
 	@docker run -t --rm -u $(shell id -u):$(shell id -g)                         \
-		-v $(PWD)/$(GOTMP):/go$(DOCKERMOUNTFLAG)                                                 \
-		-v $(PWD):/go/src/$(PKG)$(DOCKERMOUNTFLAG)                                          \
-		-w /go/src/$(PKG)                                                  \
+		-v $(S)$$PWD/$(GOTMP):/go$(DOCKERMOUNTFLAG)                                                 \
+		-v $(S)$$PWD:/go/src/$(PKG)$(DOCKERMOUNTFLAG)                                          \
+		-w $(S)/go/src/$(PKG)                                                  \
 		$(BUILD_IMAGE)                                                     \
 		misspell $(SRC_DIRS)
 
 gometalinter:
 	@echo "gometalinter: "
 	@docker run -t --rm -u $(shell id -u):$(shell id -g)                         \
-		-v $(PWD)/$(GOTMP):/go$(DOCKERMOUNTFLAG)                                                 \
-		-v $(PWD):/go/src/$(PKG)$(DOCKERMOUNTFLAG)                                          \
-		-w /go/src/$(PKG)                                                  \
+		-v $(S)$$PWD/$(GOTMP):/go$(DOCKERMOUNTFLAG)                                                 \
+		-v $(S)$$PWD:/go/src/$(PKG)$(DOCKERMOUNTFLAG)                                          \
+		-w $(S)/go/src/$(PKG)                                                  \
 		$(BUILD_IMAGE)                                                     \
-		gometalinter $(GOMETALINTER_ARGS) $(SRC_AND_UNDER)
+		time gometalinter $(GOMETALINTER_ARGS) $(SRC_AND_UNDER)
+
+golangci-lint:
+	@echo "golangci-lint: "
+	@docker run -t --rm -u $(shell id -u):$(shell id -g)                       \
+		-v $(S)$$PWD/$(GOTMP):/go$(DOCKERMOUNTFLAG)                            \
+		-v $(S)$$PWD:/go/src/$(PKG)$(DOCKERMOUNTFLAG)                          \
+		-w $(S)/go/src/$(PKG)                                                  \
+		$(BUILD_IMAGE)                                                         \
+		time bash -c "golangci-lint run $(GOLANGCI_LINT_ARGS) $(SRC_AND_UNDER)"
 
 version:
 	@echo VERSION:$(VERSION)
 
 clean: container-clean bin-clean
+	@go clean -cache || echo "You're not running latest golang locally" # Make sure the local go cache is clean for testing
 
 container-clean:
-	$(shell rm -rf .container-* .dockerfile* .push-* linux darwin windows container VERSION.txt .docker_image)
+	@if docker image inspect $(DOCKER_REPO):$(VERSION) >/dev/null 2>&1; then docker rmi -f $(DOCKER_REPO):$(VERSION); fi
+	@rm -rf .container-* .dockerfile* .push-* linux darwin windows container VERSION.txt .docker_image
 
 bin-clean:
 	$(shell rm -rf $(GOTMP) bin .tmp)

--- a/build-tools/makefile_components/base_build_python-docker.mak
+++ b/build-tools/makefile_components/base_build_python-docker.mak
@@ -11,8 +11,6 @@ SHELL := /bin/bash
 
 PWD := $(shell pwd)
 
-BUILD_IMAGE ?= drud/golang-build-container:v0.5.2
-
 all: VERSION.txt build
 
 build: linux

--- a/build-tools/makefile_components/base_container.mak
+++ b/build-tools/makefile_components/base_container.mak
@@ -8,14 +8,18 @@ SANITIZED_DOCKER_REPO = $(subst /,_,$(DOCKER_REPO))
 
 DOTFILE_IMAGE = $(subst /,_,$(IMAGE))-$(VERSION)
 
-container: linux .container-$(DOTFILE_IMAGE) container-name
+container: .container-$(DOTFILE_IMAGE) container-name
 
-.container-$(DOTFILE_IMAGE): linux Dockerfile.in
-	@sed -e 's|UPSTREAM_REPO|$(UPSTREAM_REPO)|g' Dockerfile.in > .dockerfile
+.container-$(DOTFILE_IMAGE): $(wildcard Dockerfile Dockerfile.in) container-name
+    # UPSTREAM_REPO in the Dockerfile.in will be changed to the value from Makefile; this is deprecated.
+    # There's no reason not to just use Dockerfile now.
+	@if [ -f Dockerfile.in ]; then sed -e 's|UPSTREAM_REPO|$(UPSTREAM_REPO)|g' Dockerfile.in > .dockerfile; else cp Dockerfile .dockerfile; fi
+	# Add information about the commit into .docker_image, to be added to the build.
 	@echo "$(DOCKER_REPO):$(VERSION) commit=$(shell git describe --tags --always)"  >.docker_image
+	# Add the .docker_image into the build so it's easy to figure out where a docker image came from.
 	@echo "ADD .docker_image /$(SANITIZED_DOCKER_REPO)_VERSION_INFO.txt" >>.dockerfile
 	docker build -t $(DOCKER_REPO):$(VERSION) $(DOCKER_ARGS) -f .dockerfile .
-	@docker images -q $(DOCKER_REPO):$(VERSION) > $@
+	@docker images -q $(DOCKER_REPO):$(VERSION) >$@
 
 container-name:
 	@echo "container: $(DOCKER_REPO):$(VERSION)"


### PR DESCRIPTION
## The Problem:

* golang is up to v1.11.2
* golangci-lint has moved along
* Old build-tools in this.

## The Fix:

Update all 3. 

## The Test:

* Build ddev after build-tools is going;
* `docker run --rm -it drud/golang-build-container:v1.11.2 bash` and poke around.

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

