### PR TITLE
Update golang to 1.11.4, add gotestsum, bump golangci_lint version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,12 @@
-FROM golang:1.11.2-alpine
-ENV GOLANGCI_LINT_VERSION v1.12.3
+FROM golang:1.11.4-alpine
+ENV GOLANGCI_LINT_VERSION v1.12.5
+ENV GOTESTSUM_VERSION 0.3.2
 
 RUN apk update && apk add git bash build-base curl
 
 RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b $GOPATH/bin $GOLANGCI_LINT_VERSION
+
+RUN curl -sSL "https://github.com/gotestyourself/gotestsum/releases/download/v$GOTESTSUM_VERSION/gotestsum_${GOTESTSUM_VERSION}_linux_amd64.tar.gz" | tar -xz -C /usr/local/bin gotestsum && chmod +x /usr/local/bin/gotestsum
 
 # discussion of various tools at
 # http://blog.ralch.com/tutorial/golang-tools-inspection/


### PR DESCRIPTION
## The Problem:

Time to upgrade container golang version; get latest golangci_lint in with it.

## The Fix:

## The Test:

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

