### PR TITLE
Update tools included in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,6 @@ RUN curl -sSL "https://github.com/gotestyourself/gotestsum/releases/download/v$G
 # https://dominik.honnef.co/posts/2014/12/go-tools/#goreturns
 
 ENV GOTOOLSTOBUILD \
-        github.com/3rf/codecoroner \
         github.com/FiloSottile/vendorcheck \
         github.com/GoASTScanner/gas \
         github.com/alecthomas/gocyclo \
@@ -36,8 +35,8 @@ ENV GOTOOLSTOBUILD \
         github.com/tsenart/deadcode \
         github.com/walle/lll \
         golang.org/x/tools/cmd/goimports \
-        honnef.co/go/tools/cmd/gosimple \
-        honnef.co/go/tools/cmd/staticcheck
+        honnef.co/go/tools/cmd/staticcheck \
+        github.com/client9/misspell/cmd/misspell
 
 RUN echo "GOTOOLSTOBUILD=$GOTOOLSTOBUILD"
 
@@ -45,8 +44,6 @@ RUN for item in $GOTOOLSTOBUILD; do \
 	echo "Adding tool $item" && \
 	go get -u $item; \
 done
-
-RUN gometalinter --install
 
 # /go/bin will be mounted on top, so get everything into /usr/local/bin
 RUN cp -r /go/bin/* /usr/local/bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,8 +39,7 @@ ENV GOTOOLSTOBUILD \
         github.com/walle/lll \
         golang.org/x/tools/cmd/goimports \
         honnef.co/go/tools/cmd/gosimple \
-        honnef.co/go/tools/cmd/staticcheck \
-        honnef.co/go/tools/cmd/unused
+        honnef.co/go/tools/cmd/staticcheck
 
 RUN echo "GOTOOLSTOBUILD=$GOTOOLSTOBUILD"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,9 +22,7 @@ ENV GOTOOLSTOBUILD \
         github.com/golang/lint/golint \
         github.com/gordonklaus/ineffassign \
         github.com/jgautheron/goconst \
-        github.com/kardianos/govendor \
         github.com/golang/dep/cmd/dep \
-        github.com/Masterminds/glide \
         github.com/kisielk/errcheck \
         github.com/mdempsky/unconvert \
         github.com/mibk/dupl \


### PR DESCRIPTION
## The Problem:

* Some of the tools in the container have gone unmaintained, others have merged. 
* gometalinter install (and we don't even use it any more) was overwriting the actual current, usable tools with older ones.

## The Fix:

Minor changes to the tool list.

## The Test:

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:

Needs a release and a pushed version. 
It looks like v1.11.4 was already pushed (without making a release), so the release here should be v1.11.4.2, and should be pushed to dockerhub.
