### PR TITLE
Bump to golang 1.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.11.4-alpine
+FROM golang:1.12-alpine
 ENV GOLANGCI_LINT_VERSION v1.12.5
 ENV GOTESTSUM_VERSION 0.3.2
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ ENV GOTOOLSTOBUILD \
         github.com/alecthomas/gocyclo \
         github.com/alecthomas/gometalinter \
         github.com/client9/misspell \
-        github.com/golang/lint/golint \
+        golang.org/x/lint/golint \
         github.com/gordonklaus/ineffassign \
         github.com/jgautheron/goconst \
         github.com/golang/dep/cmd/dep \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM golang:1.12-alpine
-ENV GOLANGCI_LINT_VERSION v1.12.5
+ENV GOLANGCI_LINT_VERSION v1.15.0
 ENV GOTESTSUM_VERSION 0.3.2
 
 RUN apk update && apk add git bash build-base curl

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.12-alpine
 ENV GOLANGCI_LINT_VERSION v1.15.0
-ENV GOTESTSUM_VERSION 0.3.2
+ENV GOTESTSUM_VERSION 0.3.3
 
 RUN apk update && apk add git bash build-base curl
 

--- a/Makefile
+++ b/Makefile
@@ -38,4 +38,4 @@ include build-tools/makefile_components/base_push.mak
 include build-tools/makefile_components/base_test_python.mak
 
 test: container
-	docker run $(DOCKER_REPO):$(VERSION) errcheck
+	docker run -v  $(PWD)/test:/workdir --workdir=//workdir $(DOCKER_REPO):$(VERSION) errcheck

--- a/test/start.go
+++ b/test/start.go
@@ -1,0 +1,2 @@
+package cmd
+


### PR DESCRIPTION
## The Problem:

Golang 1.12 is out. This brings it in.
