### PR TITLE
Update to golang v1.2.7, bump tools, add packr2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,17 @@
-FROM golang:1.12.1-alpine
-ENV GOLANGCI_LINT_VERSION v1.15.0
-ENV GOTESTSUM_VERSION 0.3.3
+FROM golang:1.12.7-alpine
+ENV GOLANGCI_LINT_VERSION v1.17.1
+ENV GOTESTSUM_VERSION 0.3.5
+ENV PACKR2_VERSION 2.5.2
 
 RUN apk update && apk add git bash build-base curl
 
 RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b $GOPATH/bin $GOLANGCI_LINT_VERSION
 
 RUN curl -sSL "https://github.com/gotestyourself/gotestsum/releases/download/v$GOTESTSUM_VERSION/gotestsum_${GOTESTSUM_VERSION}_linux_amd64.tar.gz" | tar -xz -C /usr/local/bin gotestsum && chmod +x /usr/local/bin/gotestsum
+
+RUN curl -sSL "https://github.com/gobuffalo/packr/releases/download/v${PACKR2_VERSION}/packr_${PACKR2_VERSION}_linux_amd64.tar.gz" | tar -xz -C /usr/local/bin packr2 && chmod +x /usr/local/bin/packr2
+
+#https://github.com/gobuffalo/packr/releases/download/v2.5.2/packr_2.5.2_linux_amd64.tar.gz
 
 # discussion of various tools at
 # http://blog.ralch.com/tutorial/golang-tools-inspection/


### PR DESCRIPTION
## The Problem:

Time to bump versions, add packr2

## The Fix:

## The Test:

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

