### PR TITLE
Bump to go v1.13 and related version updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM golang:1.12.7-alpine
-ENV GOLANGCI_LINT_VERSION v1.17.1
+FROM golang:1.13-alpine
+ENV GOLANGCI_LINT_VERSION v1.18.0
 ENV GOTESTSUM_VERSION 0.3.5
-ENV PACKR2_VERSION 2.5.2
+ENV PACKR2_VERSION 2.6.0
 
 RUN apk update && apk add git bash build-base curl
 


### PR DESCRIPTION
## The Problem:

Golang v1.13 is out

## The Fix:

Bump it and related tools

## The Test:

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

