### PR TITLE
Bump to go 1.14.2 and add mkdocs and markdownlint-cli

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,5 @@
 version: 2
-stages:
+jobs:
   build:
     machine: true
     working_directory: /home/circleci/golang-build-container
@@ -8,7 +8,5 @@ stages:
       GOPATH: /home/circleci/go
 
     steps:
-
       - checkout
-
       - run: make container && make test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,18 @@
 FROM golang:1.14-alpine
-ENV GOLANGCI_LINT_VERSION v1.23.7
-ENV GOTESTSUM_VERSION 0.3.5
+ENV GOLANGCI_LINT_VERSION v1.27.0
+ENV GOTESTSUM_VERSION 0.4.2
 ENV PACKR2_VERSION 2.6.0
 
-RUN apk update && apk add git bash build-base curl
+RUN apk update && apk add alpine-sdk git bash build-base curl nodejs npm py3-pip python3-dev
+
+RUN npm install -g markdownlint-cli
+RUN pip3 install mkdocs
 
 RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b $GOPATH/bin $GOLANGCI_LINT_VERSION
 
 RUN curl -sSL "https://github.com/gotestyourself/gotestsum/releases/download/v$GOTESTSUM_VERSION/gotestsum_${GOTESTSUM_VERSION}_linux_amd64.tar.gz" | tar -xz -C /usr/local/bin gotestsum && chmod +x /usr/local/bin/gotestsum
 
 RUN curl -sSL "https://github.com/gobuffalo/packr/releases/download/v${PACKR2_VERSION}/packr_${PACKR2_VERSION}_linux_amd64.tar.gz" | tar -xz -C /usr/local/bin packr2 && chmod +x /usr/local/bin/packr2
-
-#https://github.com/gobuffalo/packr/releases/download/v2.5.2/packr_2.5.2_linux_amd64.tar.gz
 
 # discussion of various tools at
 # http://blog.ralch.com/tutorial/golang-tools-inspection/


### PR DESCRIPTION
## The Problem:

* Bump to golang v1.14.2
* Add mkdocs so it doesn't have to be installed to verify
* Add markdownlint-cli for the same reason.

## The Fix:

## The Test:

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

