### PR TITLE
Use latest go and golang v1.16-rc1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM golang:1.15.6-buster AS golang-base
+FROM golang:1.15.7-buster AS golang-base
 ENV GOLANGCI_LINT_VERSION v1.31.0
 ENV GOTESTSUM_VERSION 0.4.2
 ENV PACKR2_VERSION 2.6.0
-ENV GOBETA=go1.16beta1
+ENV GOBETA=go1.16rc1
 
 # npm install crashes with default buster npm, use current stable instead
 RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -


### PR DESCRIPTION
## The Problem:

go v1.16-rc1 has been released.

## The Fix:

## The Test:

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

