### PR TITLE
Bump to golang v1.16.0, remove old 1.16beta handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,6 @@
-FROM golang:1.15.7-buster AS golang-base
-ENV GOLANGCI_LINT_VERSION v1.31.0
+FROM golang:1.16.0-buster AS golang-base
+ENV GOLANGCI_LINT_VERSION v1.36.0
 ENV GOTESTSUM_VERSION 0.4.2
-ENV PACKR2_VERSION 2.6.0
-ENV GOBETA=go1.16rc1
 
 # npm install crashes with default buster npm, use current stable instead
 RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -
@@ -15,8 +13,6 @@ RUN pip3 install mkdocs
 RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b $GOPATH/bin $GOLANGCI_LINT_VERSION
 
 RUN curl -sSL "https://github.com/gotestyourself/gotestsum/releases/download/v$GOTESTSUM_VERSION/gotestsum_${GOTESTSUM_VERSION}_linux_amd64.tar.gz" | tar -xz -C /usr/local/bin gotestsum && chmod +x /usr/local/bin/gotestsum
-
-RUN curl -sSL "https://github.com/gobuffalo/packr/releases/download/v${PACKR2_VERSION}/packr_${PACKR2_VERSION}_linux_amd64.tar.gz" | tar -xz -C /usr/local/bin packr2 && chmod +x /usr/local/bin/packr2
 
 # discussion of various tools at
 # http://blog.ralch.com/tutorial/golang-tools-inspection/
@@ -39,12 +35,12 @@ ENV GOTOOLSTOBUILD \
         github.com/opennota/check/cmd/aligncheck \
         github.com/opennota/check/cmd/structcheck \
         github.com/opennota/check/cmd/varcheck \
+        github.com/gobuffalo/packr/v2/packr2 \
         github.com/stretchr/testify \
         github.com/stripe/safesql \
         github.com/tsenart/deadcode \
         github.com/walle/lll \
         golang.org/x/tools/cmd/goimports \
-        golang.org/dl/${GOBETA} \
         honnef.co/go/tools/cmd/staticcheck \
         github.com/client9/misspell/cmd/misspell
 
@@ -54,8 +50,6 @@ RUN for item in $GOTOOLSTOBUILD; do \
 	echo "Adding tool $item" && \
 	go get -u $item; \
 done
-
-RUN ${GOBETA} download && ln -s /go/bin/${GOBETA} /go/bin/go1.16 && cp -r ~/sdk /sdk
 
 # /go/bin will be mounted on top, so get everything into /usr/local/bin
 RUN cp -r /go/bin/* /usr/local/bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM golang:1.16.0-buster AS golang-base
 ENV GOLANGCI_LINT_VERSION v1.36.0
 ENV GOTESTSUM_VERSION 0.4.2
+ENV PACKR2_VERSION 2.6.0
 
 # npm install crashes with default buster npm, use current stable instead
 RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -
@@ -13,6 +14,8 @@ RUN pip3 install mkdocs
 RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b $GOPATH/bin $GOLANGCI_LINT_VERSION
 
 RUN curl -sSL "https://github.com/gotestyourself/gotestsum/releases/download/v$GOTESTSUM_VERSION/gotestsum_${GOTESTSUM_VERSION}_linux_amd64.tar.gz" | tar -xz -C /usr/local/bin gotestsum && chmod +x /usr/local/bin/gotestsum
+
+RUN curl -sSL "https://github.com/gobuffalo/packr/releases/download/v${PACKR2_VERSION}/packr_${PACKR2_VERSION}_linux_amd64.tar.gz" | tar -xz -C /usr/local/bin packr2 && chmod +x /usr/local/bin/packr2
 
 # discussion of various tools at
 # http://blog.ralch.com/tutorial/golang-tools-inspection/
@@ -35,7 +38,6 @@ ENV GOTOOLSTOBUILD \
         github.com/opennota/check/cmd/aligncheck \
         github.com/opennota/check/cmd/structcheck \
         github.com/opennota/check/cmd/varcheck \
-        github.com/gobuffalo/packr/v2/packr2 \
         github.com/stretchr/testify \
         github.com/stripe/safesql \
         github.com/tsenart/deadcode \

--- a/tests/golang-build-container/test.sh
+++ b/tests/golang-build-container/test.sh
@@ -4,4 +4,3 @@ set -eu -o pipefail
 containerspec=$1
 
 docker run --rm "${containerspec}" go version
-docker run --rm "${containerspec}" go1.16 version


### PR DESCRIPTION
## The Problem:

Bump to golang v1.16.0, remove old 1.16beta handling

## The Fix:

## The Test:

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

