### PR TITLE
Bump to 1.17.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17.2-bullseye AS golang-base
+FROM golang:1.17.2-bullseye
 ENV GOLANGCI_LINT_VERSION v1.42.1
 ENV GOTESTSUM_VERSION 1.7.0
 
@@ -17,7 +17,3 @@ RUN curl -sSL "https://github.com/gotestyourself/gotestsum/releases/download/v$G
 # /go/bin will be mounted on top, so get everything into /usr/local/bin
 RUN cp -r /go/bin/* /usr/local/bin
 
-FROM scratch
-ENV GOCACHE /go/.cache
-ENV PATH /usr/local/sbin:/usr/local/bin:/usr/local/go/bin:/usr/sbin:/usr/bin:/sbin:/bin
-COPY --from=golang-base / /

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17.2-bullseye
+FROM golang:1.17.2-bullseye AS golang-base
 ENV GOLANGCI_LINT_VERSION v1.42.1
 ENV GOTESTSUM_VERSION 1.7.0
 
@@ -17,3 +17,7 @@ RUN curl -sSL "https://github.com/gotestyourself/gotestsum/releases/download/v$G
 # /go/bin will be mounted on top, so get everything into /usr/local/bin
 RUN cp -r /go/bin/* /usr/local/bin
 
+FROM scratch
+ENV GOCACHE /go/.cache
+ENV PATH /usr/local/sbin:/usr/local/bin:/usr/local/go/bin:/usr/sbin:/usr/bin:/sbin:/bin
+COPY --from=golang-base / /

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM golang:1.17.0-bullseye AS golang-base
-ENV GOLANGCI_LINT_VERSION v1.41.1
-ENV GOTESTSUM_VERSION 0.4.2
+FROM golang:1.17.2-bullseye AS golang-base
+ENV GOLANGCI_LINT_VERSION v1.42.1
+ENV GOTESTSUM_VERSION 1.7.0
 
 # npm install crashes with default buster npm, use current stable instead
 RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -
@@ -13,43 +13,6 @@ RUN pip3 install mkdocs
 RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b $GOPATH/bin $GOLANGCI_LINT_VERSION
 
 RUN curl -sSL "https://github.com/gotestyourself/gotestsum/releases/download/v$GOTESTSUM_VERSION/gotestsum_${GOTESTSUM_VERSION}_linux_amd64.tar.gz" | tar -xz -C /usr/local/bin gotestsum && chmod +x /usr/local/bin/gotestsum
-
-# discussion of various tools at
-# http://blog.ralch.com/tutorial/golang-tools-inspection/
-# https://dominik.honnef.co/posts/2014/12/go-tools/#goreturns
-
-ENV GOTOOLSTOBUILD \
-        github.com/FiloSottile/vendorcheck \
-        github.com/GoASTScanner/gas \
-        github.com/alecthomas/gocyclo \
-        github.com/alecthomas/gometalinter \
-        github.com/client9/misspell \
-        golang.org/x/lint/golint \
-        github.com/gordonklaus/ineffassign \
-        github.com/jgautheron/goconst \
-        github.com/kisielk/errcheck \
-        github.com/mdempsky/unconvert \
-        github.com/mibk/dupl \
-        mvdan.cc/interfacer \
-        mvdan.cc/unparam \
-        github.com/opennota/check/cmd/aligncheck \
-        github.com/opennota/check/cmd/structcheck \
-        github.com/opennota/check/cmd/varcheck \
-        github.com/stretchr/testify \
-        github.com/stripe/safesql \
-        github.com/tsenart/deadcode \
-        github.com/walle/lll \
-        golang.org/x/tools/cmd/goimports \
-        honnef.co/go/tools/cmd/staticcheck \
-        github.com/client9/misspell/cmd/misspell \
-        github.com/mgechev/revive
-
-RUN echo "GOTOOLSTOBUILD=$GOTOOLSTOBUILD"
-
-RUN for item in $GOTOOLSTOBUILD; do \
-	echo "Adding tool $item" && \
-	go get -u $item; \
-done
 
 # /go/bin will be mounted on top, so get everything into /usr/local/bin
 RUN cp -r /go/bin/* /usr/local/bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16.6-buster AS golang-base
+FROM golang:1.17.0-bullseye AS golang-base
 ENV GOLANGCI_LINT_VERSION v1.41.1
 ENV GOTESTSUM_VERSION 0.4.2
 


### PR DESCRIPTION
## The Problem:

Golang upgrade to 1.17.2

Removed the thousand unused tools, reduced size by 35-40%

https://github.com/drud/ddev/pull/3309 is testing this